### PR TITLE
fix reading extra block for reads with a partial block

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -78,7 +78,7 @@ func (r *reader) ReadAt(p []byte, off int64) (n int, err error) {
 	// find our starting lba
 	startBlock := off / r.blocksize
 	endOffset := len(p) + int(off)
-	blocks := (endOffset-int(off))/int(r.blocksize) + 1
+	blocks := (endOffset-int(off))/int(r.blocksize)
 	blocks = min(blocks, int(r.lba)-int(startBlock))
 
 	// handle EOF


### PR DESCRIPTION
fixing a bug where an extra block gets added while reading - this issue doesn't affect the external behaviour of the reader (the caller gets the appropriate amount of data), but we do pull one extraneous block from the device and discard it on each `ReadAt` call.

these lines already handle reads that include a partial block (we read the full block and the remaining bytes are discarded), so we don't need the extra `+1`

```go
if endOffset%int(r.blocksize) != 0 {
	// if endoffset is not block aligned then we need to read one more block
	blocks++
}
```