### PR TITLE
Fix potential use after free for errstr on Connect retry

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -24,11 +24,7 @@
         "aarch64-linux",
         "x86_64-darwin",
         "x86_64-linux"
-      ],
-      "allow": {
-        "licenses": []
-      },
-      "semver": {}
+      ]
     }
   },
   "packages": [

--- a/iscsi.go
+++ b/iscsi.go
@@ -110,12 +110,12 @@ func (d *device) Connect() error {
 		portalStr := C.CString(d.targetPortal)
 		defer C.free(unsafe.Pointer(portalStr))
 		if retval := C.iscsi_full_connect_sync(d.Context, portalStr, C.int(d.targetLun)); retval != 0 {
-			errstr := C.iscsi_get_error(d.Context)
+			errstr := C.GoString(C.iscsi_get_error(d.Context))
 			// reset the context before retrying.  it seems like some connection
 			// errors leave the context in an inconsistent state that makes it
 			// difficult to reuse
 			d.initializeContext()
-			return fmt.Errorf("iscsi_full_connect_sync: (%d) %s", retval, C.GoString(errstr))
+			return fmt.Errorf("iscsi_full_connect_sync: (%d) %s", retval, errstr)
 		}
 		return nil
 	}, retry.Attempts(20), retry.MaxDelay(500*time.Millisecond))


### PR DESCRIPTION
`d.initializeContext()` calls `iscsi_destroy_context` which frees the memory for `errstr`.  We need to copy it into a Go string before calling `initializeContext()`