### PR TITLE
fix under-read on unaligned reads. fixes #8

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -62,6 +62,11 @@ func (r *reader) Read(p []byte) (n int, err error) {
 	return readLen, err
 }
 
+// ReadAt reads len(p) bytes from the device starting at byte offset off.  Reads
+// that are not block aligned are satisfied by reading the blocks that cover the
+// requested range.  It always reads len(p) bytes unless the request extends past
+// the last block of the device, in which case it returns the bytes up to the end
+// of the device along with io.EOF.
 func (r *reader) ReadAt(p []byte, off int64) (n int, err error) {
 	if r.closed.Load() {
 		return 0, ErrDeviceClosed
@@ -70,56 +75,58 @@ func (r *reader) ReadAt(p []byte, off int64) (n int, err error) {
 	r.waiter.Add(1)
 	defer r.waiter.Done()
 
-	if off >= r.blocksize*r.lba {
-		logger().Debug("offset past at EOF", slog.Int("offset", int(off)))
+	deviceSize := r.blocksize * r.lba
+	if off >= deviceSize {
+		logger().Debug("offset past at EOF", slog.Int64("offset", off))
 		return 0, io.EOF
 	}
-	logger().Debug("ReadAt", slog.Int("bytes", len(p)), slog.Int("offset", int(off)))
-	// find our starting lba
-	startBlock := off / r.blocksize
-	endOffset := len(p) + int(off)
-	blocks := (endOffset-int(off))/int(r.blocksize)
-	blocks = min(blocks, int(r.lba)-int(startBlock))
+	if len(p) == 0 {
+		return 0, nil
+	}
+	logger().Debug("ReadAt", slog.Int("bytes", len(p)), slog.Int64("offset", off))
 
-	// handle EOF
-	if (endOffset/int(r.blocksize)) > int(r.lba) || blocks == int(r.lba-startBlock) {
+	// clamp the request to the end of the device
+	want := int64(len(p))
+	if want > deviceSize-off {
+		want = deviceSize - off
 		err = io.EOF
-		logger().Debug("reached EOF", slog.Int("lba", int(r.lba)), slog.Int("endOffset", endOffset))
-		blocks = int(r.lba - startBlock)
-	} else if endOffset%int(r.blocksize) != 0 {
-		// if endoffset is not block aligned then we need to read one more block
-		blocks++
+		logger().Debug("reached EOF", slog.Int64("lba", r.lba), slog.Int64("bytes", want))
 	}
 
-	blocks = min(blocks, int(r.lba)-int(startBlock))
+	// the blocks covering [off, off+want), including the partial blocks at
+	// either end
+	startBlock := off / r.blocksize
+	blockOffset := off % r.blocksize
+	blocks := blocksToCover(blockOffset+want, r.blocksize)
+	logger().Debug(fmt.Sprintf("offset %d into block %d", blockOffset, startBlock))
+
 	readBytes, readErr := r.dev.Read16(Read16{
 		LBA:       int(startBlock),
 		BlockSize: int(r.blocksize),
-		Blocks:    blocks,
+		Blocks:    int(blocks),
 	})
 	if readErr != nil {
 		return 0, fmt.Errorf("iscsi device read error: %w", readErr)
 	}
-
-	blockOffset := off % r.blocksize
-	logger().Debug(fmt.Sprintf("offset %d into block %d", blockOffset, startBlock))
-
-	var result []byte
-	l := min(len(p), len(readBytes))
-	if err == io.EOF {
-		result = readBytes[blockOffset:]
-	} else if blockOffset > 0 {
-		// sometimes we get fewer than the number of requested blocks
-		// even when not near the max lba? (at least when testing with gotgt)
-		// unclear yet if this is acceptable for iscsi or a flaw in gotgt
-		// make sure not to overshoot length of readBytes in that case
-		result = readBytes[blockOffset:min(l+int(blockOffset), len(readBytes))]
-	} else {
-		result = readBytes[:l]
+	if int64(len(readBytes)) < blockOffset+want {
+		// the target under-delivered.  returning what did arrive would be a
+		// short read with a nil error, which io.ReaderAt forbids
+		return 0, fmt.Errorf("read %d blocks at lba %d: got %d bytes, want %d: %w",
+			blocks, startBlock, len(readBytes), blockOffset+want, io.ErrUnexpectedEOF)
 	}
 
-	logger().Debug("finished read", slog.Int("bytes", len(result)))
-	return copy(p, result), err
+	n = copy(p[:want], readBytes[blockOffset:])
+	logger().Debug("finished read", slog.Int("bytes", n))
+	return n, err
+}
+
+// blocksToCover returns how many whole blocks are needed to hold n bytes,
+// rounding up when the last block is only partly used.  ie. with 512 byte
+// blocks, 512 bytes need 1 block and 513 bytes need 2.
+func blocksToCover(n, blocksize int64) int64 {
+	// integer division truncates, so adding blocksize-1 first rounds any
+	// partial block up to a whole one: ceil(n/blocksize)
+	return (n + blocksize - 1) / blocksize
 }
 
 // TODO: (willgorman) tests

--- a/reader_test.go
+++ b/reader_test.go
@@ -16,6 +16,196 @@ import (
 	"gotest.tools/assert"
 )
 
+// the block size gotgt always reports (api.DefaultBlockShift)
+const testBlockSize = 512
+
+type testReader interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+	io.Closer
+}
+
+// openTestReader runs a target backed by fileName and returns a reader for it.
+// the device is disconnected when the test finishes.
+func openTestReader(t *testing.T, fileName string) testReader {
+	t.Helper()
+	device := iscsi.New(iscsi.ConnectionDetails{
+		InitiatorIQN: "iqn.2024-10.libiscsi:go",
+		TargetURL:    runTestTarget(t, fileName),
+	})
+	if err := device.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = device.Disconnect() })
+
+	sreader, err := iscsi.Reader(device)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sreader
+}
+
+func TestReadAt(t *testing.T) {
+	const deviceSize = 4 * KiB // 8 blocks
+
+	seed := time.Now().UnixNano()
+	t.Logf("using seed %d", seed)
+	rnd := rand.New(rand.NewSource(seed))
+	fileName := writeTargetTempfile(t, rnd, deviceSize)
+	file, err := os.Open(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	sreader := openTestReader(t, fileName)
+
+	testCases := []struct {
+		desc    string
+		off     int64
+		length  int
+		wantN   int
+		wantEOF bool
+	}{
+		{desc: "aligned within one block", off: 0, length: 100, wantN: 100},
+		{desc: "unaligned within one block", off: 100, length: 100, wantN: 100},
+		{desc: "unaligned ending on a block boundary", off: 412, length: 100, wantN: 100},
+		{desc: "unaligned crossing a block boundary", off: 412, length: 200, wantN: 200},
+		{desc: "unaligned with an aligned end offset", off: 412, length: 612, wantN: 612},
+		{desc: "aligned across multiple blocks", off: 512, length: 1536, wantN: 1536},
+		{desc: "unaligned across multiple blocks", off: 500, length: 1600, wantN: 1600},
+		{desc: "the last block", off: deviceSize - testBlockSize, length: 512, wantN: 512},
+		{desc: "past the last block", off: deviceSize - testBlockSize, length: 1024, wantN: 512, wantEOF: true},
+		{desc: "unaligned past the last block", off: deviceSize - 100, length: 512, wantN: 100, wantEOF: true},
+		{desc: "at the end of the device", off: deviceSize, length: 512, wantEOF: true},
+		{desc: "past the end of the device", off: 2 * deviceSize, length: 512, wantEOF: true},
+		{desc: "empty buffer", off: 0, length: 0},
+		{desc: "empty buffer at an unaligned offset", off: 412, length: 0},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := make([]byte, tC.length)
+			n, err := sreader.ReadAt(got, tC.off)
+			if tC.wantEOF {
+				if !errors.Is(err, io.EOF) {
+					t.Fatalf("want io.EOF, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tC.wantN, n)
+
+			want := make([]byte, tC.wantN)
+			if tC.wantN > 0 {
+				if _, err := file.ReadAt(want, tC.off); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assert.Assert(t, bytes.Equal(want, got[:n]))
+		})
+	}
+}
+
+// TestReadAtSweep reads every offset of the device at a handful of lengths to
+// cover the block boundary conditions exhaustively.
+func TestReadAtSweep(t *testing.T) {
+	const deviceSize = 4 * KiB
+
+	seed := time.Now().UnixNano()
+	t.Logf("using seed %d", seed)
+	rnd := rand.New(rand.NewSource(seed))
+	fileName := writeTargetTempfile(t, rnd, deviceSize)
+	file, err := os.Open(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	sreader := openTestReader(t, fileName)
+
+	for _, length := range []int{1, 100, testBlockSize - 1, testBlockSize, testBlockSize + 1, 1000} {
+		for off := int64(0); off < deviceSize; off++ {
+			wantN := min(int64(length), deviceSize-off)
+
+			got := make([]byte, length)
+			n, err := sreader.ReadAt(got, off)
+			if wantN < int64(length) {
+				if !errors.Is(err, io.EOF) {
+					t.Fatalf("ReadAt(%d bytes, %d): want io.EOF, got %v", length, off, err)
+				}
+			} else if err != nil {
+				t.Fatalf("ReadAt(%d bytes, %d): %v", length, off, err)
+			}
+			if int64(n) != wantN {
+				t.Fatalf("ReadAt(%d bytes, %d): read %d bytes, want %d", length, off, n, wantN)
+			}
+
+			want := make([]byte, wantN)
+			if _, err := file.ReadAt(want, off); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(want, got[:n]) {
+				t.Fatalf("ReadAt(%d bytes, %d): data mismatch", length, off)
+			}
+		}
+	}
+}
+
+// TestReadSequentialUnaligned drives Read with buffer sizes that leave the
+// reader at an unaligned offset, where reads that span an extra block used to
+// come back short.
+func TestReadSequentialUnaligned(t *testing.T) {
+	const deviceSize = 64 * KiB
+
+	seed := time.Now().UnixNano()
+	t.Logf("using seed %d", seed)
+	rnd := rand.New(rand.NewSource(seed))
+	fileName := writeTargetTempfile(t, rnd, deviceSize)
+	file, err := os.Open(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	sreader := openTestReader(t, fileName)
+
+	// 700%512 == 188, so all but the first read starts at an unaligned offset
+	sizes := []int{700, 700, 700, 300, 512, 513, 1, 511, 1000}
+	var total int64
+	for i := 0; ; i++ {
+		if total > deviceSize {
+			t.Fatalf("read %d bytes from a %d byte device", total, int64(deviceSize))
+		}
+		size := sizes[i%len(sizes)]
+		got := make([]byte, size)
+		n, err := sreader.Read(got)
+		if err != nil && !errors.Is(err, io.EOF) {
+			t.Fatalf("read %d bytes at offset %d: %v", size, total, err)
+		}
+
+		want := make([]byte, n)
+		if _, err := file.ReadAt(want, total); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(want, got[:n]) {
+			t.Fatalf("data mismatch at offset %d", total)
+		}
+
+		if errors.Is(err, io.EOF) {
+			total += int64(n)
+			break
+		}
+		if n != size {
+			t.Fatalf("read %d bytes at offset %d, want %d", n, total, size)
+		}
+		total += int64(n)
+	}
+	if total != deviceSize {
+		t.Fatalf("read %d bytes, want %d", total, int64(deviceSize))
+	}
+}
+
 func TestRead(t *testing.T) {
 	seed := time.Now().UnixNano()
 	t.Logf("using seed %d", seed)
@@ -108,6 +298,9 @@ func TestReadRandom(t *testing.T) {
 
 		if scsiErr != nil && scsiErr != io.EOF {
 			t.Fatal(scsiErr)
+		}
+		if scsiErr == nil && scsiN != n {
+			t.Fatalf("read %d bytes, want %d", scsiN, n)
 		}
 		assert.Equal(t, fileN, scsiN)
 		assert.Assert(t, bytes.Equal(fileBytes, scsiBytes))


### PR DESCRIPTION
The logic for handling unaligned reads has never been correct.   It based the number of blocks to read entirely off of `len(p)/blocksize` without accounting for `off%blocksize` to determine how far into the starting block the read begins    Prior to #5 there was an incorrect "fix" for this problem that would add an extra block to the read in some cases and keep us from returning too few blocks for unaligned reads but could instead return too many blocks.  With #5 this switched and it became possible to return too little data on unaligned reads.

This change allows us to determine the correct number of blocks to read for unaligned reads.  It also includes additional protection for any case where the target returns fewer bytes than requested without an error.